### PR TITLE
Fix description for result code 1017.

### DIFF
--- a/src/docx/result_codes.xml
+++ b/src/docx/result_codes.xml
@@ -99,7 +99,7 @@
     </row>    
     <row>
      <entry>1017</entry>
-     <entry>Previously Reversed</entry>
+     <entry>Incorrect PIN</entry>
     </row>
     <row>
      <entry>1018</entry>


### PR DESCRIPTION
The current version of the CMF spec states that RC 1017 means `Previously reversed`. This commit changes that to `Incorrect PIN`, which aligns with the ISO-8583:2003 standard.