### PR TITLE
New reason and function code are added

### DIFF
--- a/src/docx/function_codes.xml
+++ b/src/docx/function_codes.xml
@@ -87,6 +87,11 @@
     </row>
     <row>
      <entry>184</entry>
+     <entry>Partial authorization supported by terminal, Support approved only the purchase and not the cashback
+     </entry>
+    </row>
+    <row>
+     <entry>184</entry>
      <entry>jCard private use: 
          <xref linkend="S.de_113.20" endterm='de_113.20' /> contains wallet ID
      </entry>

--- a/src/docx/result_codes.xml
+++ b/src/docx/result_codes.xml
@@ -38,6 +38,10 @@
      <entry>Approved (VIP)</entry>
     </row>
     <row>
+     <entry>0004</entry>
+     <entry>Approved only the purchase and not the cashback</entry>
+    </row>
+    <row>
      <entry>1001</entry>
      <entry>Card Expired</entry>
     </row>


### PR DESCRIPTION
These new codes are added to support partial authorizations in cashback transactions where only the purchase is approved, not the cashback.