### PR TITLE
fix: Function codes table

### DIFF
--- a/src/docx/function_codes.xml
+++ b/src/docx/function_codes.xml
@@ -28,7 +28,7 @@
      <entry>Reserved</entry>
     </row>
     <row>
-     <entry morerows="11">100-199<?br?> Used in 100, 101, 120, 121, and 140 messages to indicate
+     <entry morerows="14">100-199<?br?> Used in 100, 101, 120, 121, and 140 messages to indicate
       type of authorization or verification transaction. </entry>
      <entry>100</entry>
      <entry>Original authorization - amount accurate</entry>
@@ -87,17 +87,17 @@
     </row>
     <row>
      <entry>184</entry>
-     <entry>Partial authorization supported by terminal, Support approved only the purchase and not the cashback
-     </entry>
-    </row>
-    <row>
-     <entry>184</entry>
      <entry>jCard private use: 
          <xref linkend="S.de_113.20" endterm='de_113.20' /> contains wallet ID
      </entry>
     </row>
     <row>
-     <entry>185-199</entry>
+     <entry>185</entry>
+     <entry>Partial authorization supported by terminal, Support approved only the purchase and not the cashback
+     </entry>
+    </row>
+    <row>
+     <entry>186-199</entry>
      <entry>Additional reserved for private use</entry>
     </row>
     <row>


### PR DESCRIPTION
New records were recently added to the function code table.

The table have a collision, two records use the same code (184), also The table was visually cluttered.

These changes resolve the code collision and correct visual structure.