### PR TITLE
Add data element 48 — Additional private data

### DIFF
--- a/src/docx/constants.ent
+++ b/src/docx/constants.ent
@@ -1,4 +1,4 @@
 <!ENTITY PRODUCTNAME "jPOS Common Message Format">
-<!ENTITY VERSION "1.0.20.rc10">
+<!ENTITY VERSION "1.0.20.rc11">
 <!ENTITY COMPANY_ABBR "jPOS Software SRL">
 

--- a/src/docx/data_elements.xml
+++ b/src/docx/data_elements.xml
@@ -2511,6 +2511,87 @@
    </table>
   </simplesect>
  </sect1><?hard-pagebreak?>
+
+ <sect1 xml:id="S.de_048">
+  <title xml:id="de_048">DE-048 Additional private data</title>
+  <indexterm>
+   <primary>Data Elements</primary>
+   <secondary>DE 048, Addicional private data</secondary>
+  </indexterm>
+  <simplesect>
+   <title>Data Element: 48</title>
+   <para/>
+  </simplesect>
+  <simplesect>
+   <title>Format: B..9999, LLLVAR</title>
+   <para/>
+  </simplesect>
+  <simplesect>
+   <title>Description</title>
+   <para> The <emphasis role="italic">additional private data</emphasis> field is a composite data
+    element containing information related to 3D-Secure transactions. </para>
+   <table frame="topbot">
+    <title>DE 48 subfields</title>
+    <tgroup cols="4" align="left" colsep="1" rowsep="1">
+     <colspec colname="name"/>
+     <colspec colname="format" colwidth="2*"/>
+     <thead>
+      <row>
+       <entry>Bit</entry>
+       <entry>Name</entry>
+       <entry>Format</entry>
+       <entry>Representation</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>1</entry>
+       <entry>CAVV/AAV/AEVV data.</entry>
+       <entry>LLVAR</entry>
+       <entry>AN..40</entry>
+      </row>
+      <row>
+       <entry>2</entry>
+       <entry>Electronic commerce indicator (ECI).
+         <para>
+           <itemizedlist>
+             <listitem>
+               <para><emphasis role="bold">05</emphasis> Authentication successful</para>
+             </listitem>
+             <listitem>
+               <para><emphasis role="bold">06</emphasis> Authentication attempted</para>
+             </listitem>
+             <listitem>
+               <para><emphasis role="bold">07</emphasis> Authentication failed/not permitted</para>
+             </listitem>
+           </itemizedlist>
+         </para>
+       </entry>
+       <entry></entry>
+       <entry>AN 2</entry>
+      </row>
+      <row>
+       <entry>3</entry>
+       <entry>Transaction identifier (XID).
+         <para>
+           Typically, a 28-character base64-encoded value or a 20-character hexadecimal representation.   
+         </para>
+       </entry>
+       <entry>LLVAR</entry>
+       <entry>AN..28</entry>
+      </row>
+      <row>
+       <entry>4</entry>
+       <entry>CAVV verification result code.</entry>
+       <entry></entry>
+       <entry>AN 1</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </simplesect>
+ </sect1><?hard-pagebreak?>
+
  <sect1 xml:id="S.de_049">
   <title xml:id="de_049">DE-049 Verification data</title>
   <indexterm>

--- a/src/docx/revision_history.xml
+++ b/src/docx/revision_history.xml
@@ -22,6 +22,16 @@
    </thead>
    <tbody>
      <row>
+      <entry>Mar, 2025</entry>
+      <entry>1.0.20.rc11</entry>
+      <entry>Federico González</entry>
+      <entry>
+        <itemizedlist>
+          <listitem><para>Added data element 48 - Additional private data</para></listitem>
+        </itemizedlist>
+      </entry>
+     </row>
+     <row>
       <entry>Feb, 2025</entry>
       <entry>1.0.20.rc10</entry>
       <entry>Federico González</entry>


### PR DESCRIPTION
This pull request adds a new data element — _DE 48, Additional private data_ — which is used to hold information related to 3D-Secure transactions.

This is how the new section looks like:

![image](https://github.com/user-attachments/assets/5f3fbf16-4b5c-4bf5-9838-7c1e3d8e5f7e)
