### PR TITLE
Add table of address verification result codes.

### DIFF
--- a/src/docx/avs_codes.xml
+++ b/src/docx/avs_codes.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE appendix [
+<!ENTITY % constants SYSTEM "constants.ent" >
+%constants;
+]>
+
+<appendix xml:id="avs_codes" xmlns="http://docbook.org/ns/docbook" version="5.0">
+ <title>Address verification result codes</title>
+ <para> The following table specifies the Address Verification Result codes returned in DE-049 SE-002 (see <xref linkend="S.de_049"/>). </para>
+
+ <table frame="all">
+  <title>Address verification result codes</title>
+  <tgroup cols="2" align="left" colsep="1" rowsep="1">
+   <colspec colname="c2" colwidth="2*"/>
+   <colspec colname="c3" colwidth="6*"/>
+   <thead>
+    <row>
+     <entry>Code</entry>
+     <entry>Description</entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry>X</entry>
+     <entry>Address and 9-digit postal code match.</entry>
+    </row>
+    <row>
+     <entry>Y</entry>
+     <entry>Address and 5-digit postal code match.</entry>
+    </row>
+    <row>
+     <entry>A</entry>
+     <entry>Address matches, postal code does not.</entry>
+    </row>
+    <row>
+     <entry>W</entry>
+     <entry>9-digit postal code matches, address does not.</entry>
+    </row>
+    <row>
+     <entry>Z</entry>
+     <entry>5-digit postal code matches, address does not.</entry>
+    </row>
+    <row>
+     <entry>N</entry>
+     <entry>Nothing matches.</entry>
+    </row>
+    <row>
+     <entry>R</entry>
+     <entry>Retry, system unable to process.</entry>
+    </row>
+    <row>
+     <entry>S</entry>
+     <entry>Address verification service not supported.</entry>
+    </row>
+    <row>
+     <entry>U</entry>
+     <entry>Address verification not performed by card-issuing entity.</entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </table>
+</appendix>

--- a/src/docx/constants.ent
+++ b/src/docx/constants.ent
@@ -1,4 +1,4 @@
 <!ENTITY PRODUCTNAME "jPOS Common Message Format">
-<!ENTITY VERSION "1.0.20.rc13">
+<!ENTITY VERSION "1.0.20.rc14">
 <!ENTITY COMPANY_ABBR "jPOS Software SRL">
 

--- a/src/docx/data_elements.xml
+++ b/src/docx/data_elements.xml
@@ -3164,7 +3164,7 @@
       </row>
       <row>
        <entry>2</entry>
-       <entry>Address verification result code</entry>
+       <entry>Address verification result code (see <xref linkend="avs_codes"/>)</entry>
        <entry/>
        <entry>AN1</entry>
       </row>

--- a/src/docx/jPOS-CMF.xml
+++ b/src/docx/jPOS-CMF.xml
@@ -51,6 +51,7 @@
   <xi:include href="error_codes.xml"/>
   <xi:include href="mcc.xml"/>
   <xi:include href="service_result_codes.xml"/>
+  <xi:include href="avs_codes.xml"/>
   <xi:include href="revision_history.xml"/>
   <xi:include href="license.xml"/>
   <xi:include href="glossary.xml"/>

--- a/src/docx/revision_history.xml
+++ b/src/docx/revision_history.xml
@@ -22,6 +22,16 @@
    </thead>
    <tbody>
      <row>
+      <entry>Jul, 2025</entry>
+      <entry>1.0.20.rc14</entry>
+      <entry>Federico González</entry>
+      <entry>
+        <itemizedlist>
+          <listitem><para>Added table of Address Verification result codes (see <xref linkend="avs_codes" />).</para></listitem>
+        </itemizedlist>
+      </entry>
+     </row>
+     <row>
       <entry>Mar, 2025</entry>
       <entry>1.0.20.rc13</entry>
       <entry>Federico González</entry>


### PR DESCRIPTION
This pull request adds a new appendix for the address verification result codes  returned in field 49.2.

Both the appendix and definition of DE 49.2 are cross-linked now. 

See updated PDF here: [jPOS-CMF.pdf](https://github.com/user-attachments/files/21044273/jPOS-CMF.pdf)
