### PR TITLE
Add definition for data element 16 - conversion date.

### DIFF
--- a/src/docx/constants.ent
+++ b/src/docx/constants.ent
@@ -1,4 +1,4 @@
 <!ENTITY PRODUCTNAME "jPOS Common Message Format">
-<!ENTITY VERSION "1.0.20.rc15">
+<!ENTITY VERSION "1.0.20.rc16">
 <!ENTITY COMPANY_ABBR "jPOS Software SRL">
 

--- a/src/docx/data_elements.xml
+++ b/src/docx/data_elements.xml
@@ -726,6 +726,27 @@
     </para>
   </simplesect>
  </sect1><?hard-pagebreak?>
+ <sect1 xml:id="S.de_016">
+  <title xml:id="de_016">DE-016 Conversion date</title>
+  <indexterm>
+   <primary>Data Elements</primary>
+   <secondary>DE 016, Conversion date</secondary>
+  </indexterm>
+  <simplesect>
+   <title>Data Element: 16</title>
+   <para/>
+  </simplesect>
+  <simplesect>
+   <title>Format: N4 (MMDD)</title>
+   <para/>
+  </simplesect>
+  <simplesect>
+   <title>Description</title>
+   <para> 
+      The month and day the conversion rate is effective to convert the transaction amount from the original to reconciliation currency.
+    </para>
+  </simplesect>
+ </sect1><?hard-pagebreak?>
  <sect1 xml:id="S.de_017">
   <title xml:id="de_017">DE-017 Capture date</title>
   <indexterm>

--- a/src/docx/revision_history.xml
+++ b/src/docx/revision_history.xml
@@ -23,6 +23,18 @@
    <tbody>
      <row>
       <entry>Jul, 2025</entry>
+      <entry>1.0.20.rc16</entry>
+      <entry>Federico González</entry>
+      <entry>
+        <itemizedlist>
+            <listitem>
+                <para>Added Data element 16 — Conversion date (see <xref linkend="S.de_016" />).</para>
+            </listitem>
+        </itemizedlist>
+      </entry>
+     </row>
+     <row>
+      <entry>Jul, 2025</entry>
       <entry>1.0.20.rc15</entry>
       <entry>Federico González</entry>
       <entry>


### PR DESCRIPTION
This pull request adds the definition of data element 16, conversion date:

```
The month and day the conversion rate is effective to convert the transaction 
amount from the original to reconciliation currency.
```

See updated PDF [here](https://github.com/user-attachments/files/21536407/jPOS-CMF.pdf).
