### PR TITLE
Add result code 9107 — card issuer or switch inoperative.

### DIFF
--- a/src/docx/constants.ent
+++ b/src/docx/constants.ent
@@ -1,4 +1,4 @@
 <!ENTITY PRODUCTNAME "jPOS Common Message Format">
-<!ENTITY VERSION "1.0.20.rc16">
+<!ENTITY VERSION "1.0.20.rc17">
 <!ENTITY COMPANY_ABBR "jPOS Software SRL">
 

--- a/src/docx/result_codes.xml
+++ b/src/docx/result_codes.xml
@@ -439,7 +439,10 @@
       <entry>9102</entry>
       <entry>Invalid transaction</entry>
     </row>       
-
+    <row>
+      <entry>9107</entry>
+      <entry>Card issuer or switch inoperative</entry>
+    </row>       
    </tbody>
   </tgroup>
  </table>

--- a/src/docx/revision_history.xml
+++ b/src/docx/revision_history.xml
@@ -22,6 +22,18 @@
    </thead>
    <tbody>
      <row>
+      <entry>Aug, 2025</entry>
+      <entry>1.0.20.rc17</entry>
+      <entry>Federico González</entry>
+      <entry>
+        <itemizedlist>
+            <listitem>
+                <para>Added result code 9107 (see <xref linkend="result_codes" />).</para>
+            </listitem>
+        </itemizedlist>
+      </entry>
+     </row>
+     <row>
       <entry>Jul, 2025</entry>
       <entry>1.0.20.rc16</entry>
       <entry>Federico González</entry>


### PR DESCRIPTION
Ditto.

See [updated PDF](https://github.com/user-attachments/files/21666081/jPOS-CMF.pdf).
