### PR TITLE
Add DE-113.38 Cardholder Name Verification Response

### DIFF
--- a/src/docx/cnv_codes.xml
+++ b/src/docx/cnv_codes.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE appendix [
+<!ENTITY % constants SYSTEM "constants.ent" >
+%constants;
+]>
+
+<appendix xml:id="cnv_codes" xmlns="http://docbook.org/ns/docbook" version="5.0">
+ <title>Cardholder Name Verification response codes</title>
+ <para> The following table specifies the Cardholder Name Verification response codes returned in DE-113.38 (see <xref linkend="S.de_113.38"/>). </para>
+
+ <table frame="all">
+  <title>Cardholder Name Verification response codes</title>
+  <tgroup cols="2" align="left" colsep="1" rowsep="1">
+   <colspec colname="c1" colwidth="2*"/>
+   <colspec colname="c2" colwidth="6*"/>
+   <thead>
+    <row>
+     <entry>Code</entry>
+     <entry>Description</entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry>M</entry>
+     <entry>Full Match: Name matches issuer records perfectly.</entry>
+    </row>
+    <row>
+     <entry>P</entry>
+     <entry>Partial Match: First/Last name matches; minor layout or initial variance.</entry>
+    </row>
+    <row>
+     <entry>N</entry>
+     <entry>Mismatch: Name does not match issuer files.</entry>
+    </row>
+    <row>
+     <entry>U</entry>
+     <entry>Unavailable: Issuer or country network does not support name matching.</entry>
+    </row>
+    <row>
+     <entry>S</entry>
+     <entry>System Error: Timeout or processing failure at the network switch.</entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </table>
+</appendix>

--- a/src/docx/constants.ent
+++ b/src/docx/constants.ent
@@ -1,4 +1,4 @@
 <!ENTITY PRODUCTNAME "jPOS Common Message Format">
-<!ENTITY VERSION "1.0.20.rc20">
+<!ENTITY VERSION "1.0.20.rc21">
 <!ENTITY COMPANY_ABBR "jPOS Software SRL">
 

--- a/src/docx/jPOS-CMF.xml
+++ b/src/docx/jPOS-CMF.xml
@@ -52,6 +52,7 @@
   <xi:include href="mcc.xml"/>
   <xi:include href="service_result_codes.xml"/>
   <xi:include href="avs_codes.xml"/>
+  <xi:include href="cnv_codes.xml"/>
   <xi:include href="revision_history.xml"/>
   <xi:include href="license.xml"/>
   <xi:include href="glossary.xml"/>

--- a/src/docx/jcard_data_elements.xml
+++ b/src/docx/jcard_data_elements.xml
@@ -725,6 +725,29 @@
    </para>
   </simplesect>
  </sect1>
+ <sect1 xml:id="S.de_113.38">
+  <title xml:id="de_113.38">DE-113.38 Cardholder Name Verification Response</title>
+  <indexterm>
+   <primary>Data Elements</primary>
+   <secondary>DE 113.38 - Cardholder Name Verification Response</secondary>
+  </indexterm>
+  <simplesect>
+   <title>Data Element: 113.38</title>
+   <para/>
+  </simplesect>
+  <simplesect>
+   <title>Format: AN1</title>
+   <para/>
+  </simplesect>
+  <simplesect>
+   <title>Description</title>
+   <para>
+    Cardholder name verification response code returned by the issuer indicating
+    the result of matching the cardholder name against issuer records.
+    See <xref linkend="cnv_codes"/> for valid values and network mappings.
+   </para>
+  </simplesect>
+ </sect1>
  <sect1 xml:id="S.de_113.39">
   <title xml:id="de_113.39">DE-113.39 Remote Result Code</title>
   <indexterm>

--- a/src/docx/revision_history.xml
+++ b/src/docx/revision_history.xml
@@ -22,6 +22,21 @@
    </thead>
    <tbody>
      <row>
+      <entry>Jun, 2026</entry>
+      <entry>1.0.20.rc21</entry>
+      <entry>Federico González</entry>
+      <entry>
+        <itemizedlist>
+            <listitem>
+                <para>Added data element <xref linkend="S.de_113.38"/> — Cardholder Name Verification Response.</para>
+            </listitem>
+            <listitem>
+                <para>Added table of Cardholder Name Verification response codes (see <xref linkend="cnv_codes"/>).</para>
+            </listitem>
+        </itemizedlist>
+      </entry>
+     </row>
+     <row>
       <entry>Feb, 2026</entry>
       <entry>1.0.20.rc20</entry>
       <entry>Gregorio Osorio</entry>


### PR DESCRIPTION
- Added DE-113.38 (AN1) to jCard data elements, referencing the new appendix.
- Added cnv_codes appendix with the five CMF response codes (M, P, N, U, S).
- Bumped version to 1.0.20.rc21 and added revision history entry.