### PR TITLE
docs: add DE 113.34 — Extended Authorization Indicator (v1.0.20.rc22)

### DIFF
--- a/src/docx/constants.ent
+++ b/src/docx/constants.ent
@@ -1,4 +1,4 @@
 <!ENTITY PRODUCTNAME "jPOS Common Message Format">
-<!ENTITY VERSION "1.0.20.rc21">
+<!ENTITY VERSION "1.0.20.rc22">
 <!ENTITY COMPANY_ABBR "jPOS Software SRL">
 

--- a/src/docx/jcard_data_elements.xml
+++ b/src/docx/jcard_data_elements.xml
@@ -725,6 +725,36 @@
    </para>
   </simplesect>
  </sect1>
+ <sect1 xml:id="S.de_113.34">
+  <title xml:id="de_113.34">DE-113.34 Extended Authorization Indicator</title>
+  <indexterm>
+   <primary>Data Elements</primary>
+   <secondary>DE 113.34 - Extended Authorization Indicator</secondary>
+  </indexterm>
+  <simplesect>
+   <title>Data Element: 113.34</title>
+   <para/>
+  </simplesect>
+  <simplesect>
+   <title>Format: AN1</title>
+   <para/>
+  </simplesect>
+  <simplesect>
+   <title>Description</title>
+   <para>
+    Indicates whether a transaction is an extended authorization. When present, the authorization expiry
+    is extended beyond the standard period.
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para><emphasis role="bold">Y</emphasis> — Extended authorization.</para>
+    </listitem>
+    <listitem>
+     <para><emphasis role="bold">Absent</emphasis> — Standard authorization.</para>
+    </listitem>
+   </itemizedlist>
+  </simplesect>
+ </sect1>
  <sect1 xml:id="S.de_113.38">
   <title xml:id="de_113.38">DE-113.38 Cardholder Name Verification Response</title>
   <indexterm>

--- a/src/docx/revision_history.xml
+++ b/src/docx/revision_history.xml
@@ -23,6 +23,18 @@
    <tbody>
      <row>
       <entry>Jun, 2026</entry>
+      <entry>1.0.20.rc22</entry>
+      <entry>Federico González</entry>
+      <entry>
+        <itemizedlist>
+            <listitem>
+                <para>Added data element <xref linkend="S.de_113.34"/> — Extended Authorization Indicator.</para>
+            </listitem>
+        </itemizedlist>
+      </entry>
+     </row>
+     <row>
+      <entry>Jun, 2026</entry>
       <entry>1.0.20.rc21</entry>
       <entry>Federico González</entry>
       <entry>


### PR DESCRIPTION
Introduces a network-agnostic AN1 field to indicate extended authorizations. Value 'Y' signals an extended auth (expiry beyond the standard period); absent field indicates a standard authorization.