### PR TITLE
Add 400 reversal message support

### DIFF
--- a/src/docx/constants.ent
+++ b/src/docx/constants.ent
@@ -1,4 +1,3 @@
 <!ENTITY PRODUCTNAME "jPOS Common Message Format">
-<!ENTITY VERSION "1.0.20.rc22">
+<!ENTITY VERSION "1.0.20.rc23">
 <!ENTITY COMPANY_ABBR "jPOS Software SRL">
-

--- a/src/docx/data_elements.xml
+++ b/src/docx/data_elements.xml
@@ -309,6 +309,17 @@
       </row>
       <row>
        <entry>
+        <emphasis role="bold">400</emphasis>
+       </entry>
+       <entry>
+        <emphasis role="bold">XX</emphasis>
+       </entry>
+       <entry>Reversal - use same code as original <emphasis role="italic">(See <xref
+          linkend="reversal"/>)</emphasis>
+       </entry>
+      </row>
+      <row>
+       <entry>
         <emphasis role="bold">420</emphasis>
        </entry>
        <entry>
@@ -4146,4 +4157,3 @@
     </simplesect>
   </sect1>
 </chapter>
-

--- a/src/docx/function_codes.xml
+++ b/src/docx/function_codes.xml
@@ -187,8 +187,8 @@
     </row>
 
     <row>
-     <entry morerows="4"> 400-449<?br?> Used in 420, 421 and 440 messages to indicate the function
-      of the reversal. </entry>
+     <entry morerows="4"> 400-449<?br?> Used in 400, 401, 420, 421, 440 and 441 messages to indicate
+      the function of the reversal. </entry>
      <entry>400</entry>
      <entry>Full reversal, transaction did not complete as approved</entry>
     </row>

--- a/src/docx/mti.xml
+++ b/src/docx/mti.xml
@@ -68,9 +68,14 @@
      <entry>File Update</entry>
     </row>
     <row>
+     <entry align="center"><emphasis role="bold">400</emphasis></entry>
+     <entry align="center"><emphasis role="bold">410</emphasis></entry>
+     <entry>Reversal requests for Authorization and Financial messages</entry>
+    </row>
+    <row>
      <entry align="center"><emphasis role="bold">420</emphasis></entry>
      <entry align="center"><emphasis role="bold">430</emphasis></entry>
-     <entry>Reversals of Authorization and Financial messages</entry>
+     <entry>Reversal advices for Authorization and Financial messages</entry>
     </row>
     <row>
      <entry align="center"><emphasis role="bold">600</emphasis></entry>
@@ -106,4 +111,3 @@
   </tgroup>
  </table>
 </section>
-

--- a/src/docx/revision_history.xml
+++ b/src/docx/revision_history.xml
@@ -23,6 +23,18 @@
    <tbody>
      <row>
       <entry>Jun, 2026</entry>
+      <entry>1.0.20.rc23</entry>
+      <entry>Alejandro Revilla</entry>
+      <entry>
+        <itemizedlist>
+            <listitem>
+                <para>Added reversal request/response message type identifiers 400 and 410.</para>
+            </listitem>
+        </itemizedlist>
+      </entry>
+     </row>
+     <row>
+      <entry>Jun, 2026</entry>
       <entry>1.0.20.rc22</entry>
       <entry>Federico González</entry>
       <entry>

--- a/src/docx/txn_reversal.xml
+++ b/src/docx/txn_reversal.xml
@@ -6,7 +6,7 @@
 <section xml:id="reversal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0">
  <title>Reversals</title>
  <indexterm><primary>Reversals</primary></indexterm>
- <indexterm><primary>420, 430</primary></indexterm>
+ <indexterm><primary>400, 410, 420, 430</primary></indexterm>
 
  <table frame="all" tocentry="1">
   <title>Reversals</title>
@@ -30,8 +30,8 @@
      <entry align="right"><emphasis role="bold">MTI</emphasis></entry>
      <entry>Message Type indicator</entry>
      <entry/>
-     <entry align="center"><emphasis role="bold">420</emphasis></entry>
-     <entry align="center"><emphasis role="bold">430</emphasis></entry>
+     <entry align="center"><emphasis role="bold">400</emphasis>, <emphasis role="bold">420</emphasis></entry>
+     <entry align="center"><emphasis role="bold">410</emphasis>, <emphasis role="bold">430</emphasis></entry>
     </row>
     <row>
      <entry align="right"><emphasis role="bold">2</emphasis></entry>
@@ -233,4 +233,3 @@
      <para>See <xref linkend="conditionals" /> for condition details.</para>
  </note>
 </section>
-


### PR DESCRIPTION
## Summary
- add 400/410 reversal request/response MTIs alongside the existing 420/430 reversal advice path
- document 400 in the reversal transaction table, DE-003 TTC guidance, and DE-024 reversal function-code usage
- bump the spec revision to 1.0.20.rc23 with a revision history entry

## Verification
- source ~/.sdkman/bin/sdkman-init.sh && sdk env install && sdk env && $MAVEN_HOME/bin/mvn -q -DskipTests package
- xmllint --noout --loaddtd on touched DocBook XML files
- git diff --check